### PR TITLE
ci: Fix format of octocov report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Run tests
         run: uv run poe test --cov-report xml
         working-directory: libs/common
-      - if: ${{ !cancelled() }}
+      - if: ${{ matrix.python-version == '3.12' && !cancelled() }}
         uses: k1LoW/octocov-action@v1
         with:
           config: libs/common/.octocov.yml

--- a/libs/common/.octocov.yml
+++ b/libs/common/.octocov.yml
@@ -1,3 +1,4 @@
+repository: inuatsu/python-monorepo-sample/libs/common
 coverage:
   paths:
     - coverage.xml


### PR DESCRIPTION
- Send octocov report only for Python 3.12
- Add directory name in report